### PR TITLE
New feature: support all available languages on leetcode and crawl code snippets of multiple languages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,20 @@ Options:
   -h, --help           display help for command
 ```
 
-with `-l`, now support:
+with `-l`, support:
 ```
-    csharp -> '.cs',
-    java -> '.java',
-    javascript -> '.js',
-    php -> '.php',
-    python -> '.py',
-    python3 -> '.py'
-    cpp -> '.cpp'
+    csharp -> '.cs', java -> '.java', javascript -> '.js',
+    php -> '.php', python -> '.py', python3 -> '.py',
+    cpp -> '.cpp', c -> '.c', ruby -> '.rb',
+    swift -> '.swift', golang -> '.go', scala -> '.scala',
+    kotlin -> '.kt', rust -> '.rs', typescript -> '.ts',
+    racket -> '.rkt', erlang -> '.erl', elixir -> '.ex',
+    dart -> '.dart'
+```
+
+crawling problem 5 of C++, Java and Python3 code snippets:
+```
+$ npx leetcode-problems-crawler -r 5 -l cpp,java,python3
 ```
 
 Welcome folk and customization.

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,19 @@ export default {
     php: '.php',
     python: '.py',
     python3: '.py',
-    cpp: '.cpp'
+    cpp: '.cpp',
+    c: '.c',
+    ruby: '.rb',
+    swift: '.swift',
+    golang: '.go',
+    scala: '.scala',
+    kotlin: '.kt',
+    rust: '.rs',
+    typescript: '.ts',
+    racket: '.rkt',
+    erlang: '.erl',
+    elixir: '.ex',
+    dart: '.dart'
   },
   levelMap: {
     1: 'easy',

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -32,11 +32,23 @@ export function parseI18ns(i18nStr?: string) {
 }
 
 export function parseLang(lang?: string) {
-    const langs = Object.keys(config.langSlugMap)
-    if (!langs.includes(lang)) {
-        const msg = 'Invalid lang parameter value'
-        console.log(msg)
-        throw new InvalidArgumentError(msg)
+    const langStrs = [];
+    if (langStr.includes(',')) {
+        langStrs.push(...langStr.split(','));
     }
-    return lang
+    else {
+        langStrs.push(langStr);
+    }
+    const allowedLangs = Object.keys(config.langSlugMap)
+    const langs = langStrs.map(lang => {
+        if (allowedLangs.includes(lang)) {
+            return lang;
+        }
+        else {
+            const msg = 'Invalid lang parameter value';
+            console.log(msg);
+            throw new InvalidArgumentError(msg);
+        }
+    });
+    return langs;
 }

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -31,8 +31,11 @@ export function parseI18ns(i18nStr?: string) {
     return i18nStr
 }
 
-export function parseLang(lang?: string) {
+export function parseLang(langStr?: string) {
     const langStrs = [];
+    if (!langStr){
+      return ['python3'];
+    }
     if (langStr.includes(',')) {
         langStrs.push(...langStr.split(','));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,14 +25,12 @@ import {
     )
     .option(
       '-l, --lang <string>',
-      'generate code snippet with language, default is python3.',
-      helpers.parseLang,
-      'python3'
+      'generate code snippet with language, default is python3.'
     )
   program.parse()
 
   const options: InputParams = program.opts();
-  main(options.rule, options.lang, options.i18n)
+  main(options.rule, helpers.parseLang(options.lang), options.i18n)
 })()
 
 
@@ -71,7 +69,7 @@ async function main(ids: number[], langSlugs: string[], i18n: InputParams['i18n'
     writeQuestion(dirname, questionConfig)
 
     const { codeSnippets } = question
-  
+
     for (const idx in langSlugs) {
       const langSlug = langSlugs[idx];
       const snippet = codeSnippets.find((s) => s.langSlug === langSlug);

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ import {
 
 
 
-async function main(ids: number[], langSlug: string, i18n: InputParams['i18n']) {
+async function main(ids: number[], langSlugs: string[], i18n: InputParams['i18n']) {
   const { domain } = config[i18n]
   const problems = await getAllProblems(domain)
 
@@ -71,13 +71,15 @@ async function main(ids: number[], langSlug: string, i18n: InputParams['i18n']) 
     writeQuestion(dirname, questionConfig)
 
     const { codeSnippets } = question
-    const snippet = codeSnippets.find(
-      (s: { langSlug: string }) => s.langSlug === langSlug
-    )
-    if (!snippet) {
-      return
+  
+    for (const idx in langSlugs) {
+      const langSlug = langSlugs[idx];
+      const snippet = codeSnippets.find((s) => s.langSlug === langSlug);
+      if (!snippet) {
+          continue;
+      }
+      writeSolution(dirname, langSlug, snippet.code);
     }
-    writeSolution(dirname, langSlug, snippet.code)
 
     writeInformation(dirname, { question, difficulty: config.levelMap[level] })
   })


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Add new feature of supporting crawling code snippets of multiple languages at the same time.
Add new feature of supporting all available languages on leetcode.

* **What is the current behavior?** (You can also link to an open issue here)
The crawler can only save code snippet of one language at the same time.
The crawler can only save code snippets of C++, Java, C#, Python, JavaScript and PHP.


* **What is the new behavior (if this is a feature change)?**
Command to crawl C++, Java and Python3 snippets of LeetCode Problem 5:
`npx leetcode-problems-crawler -r 5 -l cpp,java,python3`
Language can also be: 'c', 'typescript', 'ruby', 'swift', 'golang', 'kotlin', 'scala', 'rust', 'dart', 'elixir', 'erlang' or 'racket'.
